### PR TITLE
Kevin/2021 01 11 mw 239 gitlab

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(name='tap-gitlab',
           'singer-python==5.9.1',
           'requests==2.20.0',
           'strict-rfc3339==0.7',
-          'backoff==1.8.0'
+          'backoff==1.8.0',
+          'psutil==5.8.0'
       ],
       entry_points='''
           [console_scripts]

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -1074,7 +1074,6 @@ def sync_project(pid, gitLocal):
         # all the PR heads with gitlab like it does for github.
         pr_heads = sync_merge_requests(data, True)
         heads.update(pr_heads)
-        # This is the only function that will update the state
         sync_commit_files(data, heads, gitLocal)
     elif data['last_activity_at'] >= get_start(state_key):
         sync_members(data)

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -217,11 +217,13 @@ def get_url(entity, id, secondary_id=None, start_date=None):
     if secondary_id and not isinstance(secondary_id, int):
         secondary_id = secondary_id.replace("/", "%2F")
 
-    return CONFIG['api_url'] + RESOURCES[entity]['url'].format(
+    url = CONFIG['api_url'] + RESOURCES[entity]['url'].format(
             id=id,
             secondary_id=secondary_id,
             start_date=start_date
         )
+    LOGGER.info('Beginning sync of entity {}, URL stream {}'.format(entity, url))
+    return url
 
 
 def get_start(entity):
@@ -649,7 +651,7 @@ def sync_group(gid, pids):
 
     if not pids:
         #  Get all the projects of the group if none are provided
-        group_projects_url = get_url(entity="group_projects", id=gid)        
+        group_projects_url = get_url(entity="group_projects", id=gid)
         for project in gen_request(group_projects_url):
             if project["id"]:
                 sync_project(project["id"])
@@ -898,6 +900,10 @@ def main_impl():
     if args.state:
         STATE.update(args.state)
 
+    # TODO: when fetching files, there is a dependency on fetching all the PRs first. Then, we will
+    # need to explicitly fetch each PR head because they are not provided with git clone --mirror
+    # like they are with github.
+
     # If discover flag was passed, log an info message and exit
     global CATALOG
     if args.discover:
@@ -913,6 +919,7 @@ def main_impl():
 
 
 def main():
+
     try:
         main_impl()
     except Exception as exc:

--- a/tap_gitlab/gitlocal.py
+++ b/tap_gitlab/gitlocal.py
@@ -1,0 +1,293 @@
+import subprocess
+import sys
+import os
+import re
+import json
+
+class GitLocalException(Exception):
+  pass
+
+def parseDiffLines(lines):
+  changes = []
+  curChange = None
+  state = 'start'
+  for line in lines:
+    if len(line) == 0:
+      # Only happens on last line -- other blank lines at least start with space
+      if curChange:
+        changes.append(curChange)
+        curChange = None
+      continue
+    elif line[0:4] == 'diff': # diff
+      # Start by assuming file names are the same, and then update later if there's a rename.
+      # Unfortunately we can't just do a regex match because " b/" could be in either file name,
+      # which would mess stuff up. So, compute the length of the string
+      fileNameLen = int((len(line) - len('diff --git a/ b/')) / 2)
+      noRenameFname = line[-fileNameLen:]
+
+      # For a pure file mode change, the change type will be none without a patch. Convert this to
+      # an edit.
+      if curChange and (curChange['changetype'] != 'none' or len(curChange['patch']) > 0 or \
+          curChange['is_binary'] or curChange['previous_filename']):
+        changes.append(curChange)
+      curChange = {
+        'filename': noRenameFname,
+        'additions': 0,
+        'deletions': 0,
+        'patch': [],
+        'previous_filename': '',
+        'is_binary': False,
+        'is_large_patch': False,
+        'changetype': 'none',
+      }
+      state = 'start'
+      pass
+    elif state == 'inpatch':
+      if line[0] == '@':
+        # Note: this line may have context at the end, which is okay and part of the git difff
+        # format.
+        curChange['patch'].append(line)
+      else:
+        if line[0] == '-':
+          curChange['deletions'] += 1
+        elif line[0] == '+':
+          curChange['additions'] += 1
+        curChange['patch'].append(line)
+    elif line[0] == 'i': # index
+      # Ignore file mode changes for now
+      pass
+    elif line[0] == 's': # similarity index...
+      pass
+    elif line[0] == 'o': # old mode...
+      pass
+    elif line[0] == 'n': # new file/mode...
+      if line[:8] == 'new mode':
+        curChange['changetype'] = 'edit'
+      else:
+        curChange['changetype'] = 'add'
+    elif line[0:3] == 'del': # deleted file
+      curChange['changetype'] = 'delete'
+    elif line[0] == 'B': # Binary files dffer
+      curChange['is_binary'] = True
+      pass
+    elif line[0] == 'r': # rename from/to...
+      if line[0:12] == 'rename from ':
+        curChange['previous_filename'] = line[12:]
+      elif line[0:10] == 'rename to ':
+        curChange['filename'] = line[10:]
+    elif line[0] == '-':
+      pass # Ignore, will be same as rename from if different from changed file name
+    elif line[0] == '+':
+      state = 'inpatch'
+    else:
+      raise GitLocalException('Unexpected line start: "{}"'.format(line))
+  for change in changes:
+    change['patch'] = '\n'.join(change['patch'])
+    if len(change['patch']) == 0:
+      change['patch'] = None
+    elif len(change['patch']) > 1024 * 1024:
+      change['patch'] = None
+      change['is_large_patch'] = True
+
+    if (change['is_binary'] or change['is_large_patch'] or change['patch']) \
+        and change['changetype'] == 'none':
+      change['changetype'] = 'edit'
+
+    # This isn't strictly necessary, but doing it to make sure that the output is exactly the same
+    # as when using the API.
+    if not change['previous_filename']:
+      del change['previous_filename']
+    if not change['patch']:
+      del change['patch']
+  return changes
+
+
+class GitLocal:
+  def __init__(self, config):
+    self.token = config['access_token']
+    self.workingDir = config['workingDir']
+    self.LS_CACHE = {}
+    self.INIT_REPO = {}
+
+  def _getOrgWorkingDir(self, repo):
+    orgName = repo.split('/')[0]
+    orgWdir = '{}/{}'.format(self.workingDir, orgName)
+    if not os.path.exists(orgWdir):
+      os.mkdir(orgWdir)
+    return orgWdir
+
+  def _getRepoWorkingDir(self, repo, source):
+    orgDir = self._getOrgWorkingDir(repo)
+    repoDir = repo.split('/')[1]
+    repoWdir = '{}/{}.git'.format(orgDir, repoDir)
+    self._initRepo(repo, repoWdir, source)
+    return repoWdir
+
+  def _cloneRepo(self, repo, repoWdir, source):
+    """
+    Clones a repository using git clone, throwing an error if the operation does not succeed
+    """
+    # If directory already exists, do an update
+    if os.path.exists(repoWdir):
+      completed = subprocess.run(['git', 'remote', 'update'], cwd=repoWdir, capture_output=True)
+      if completed.returncode != 0:
+        # Don't send the acces token through the error logging system
+        strippedOutput = completed.stderr.replace(self.token.encode('utf8'), b'<TOKEN>')
+        raise GitLocalException("Remote update of repo {} failed with code {}, message: {}"\
+          .format(repo, completed.returncode, strippedOutput))
+    else:
+      if source == 'github':
+        cloneUrl = "https://{}@github.com/{}.git".format(self.token, repo)
+      elif source == 'gitlab':
+        cloneUrl = "https://oauth2:{}@gitlab.com/{}.git".format(self.token, repo)
+      else:
+        raise Exception('Unrecognized source {}'.format(source))
+      orgDir = self._getOrgWorkingDir(repo)
+      completed = subprocess.run(['git', 'clone', '--mirror', cloneUrl], cwd=orgDir,
+        capture_output=True)
+      if completed.returncode != 0:
+        # Don't send the acces token through the error logging system
+        strippedOutput = completed.stderr.replace(self.token.encode('utf8'), b'<TOKEN>')
+        raise GitLocalException("Clone of repo {} failed with code {}, message: {}"\
+          .format(repo, completed.returncode, strippedOutput))
+
+  def _initRepo(self, repo, repoWdir, source):
+    if repo in self.INIT_REPO:
+      return
+
+    self._cloneRepo(repo, repoWdir, source)
+
+    self.INIT_REPO[repo] = True
+
+  def hasLocalCommit(self, repo, sha, source):
+    repoDir = self._getRepoWorkingDir(repo, source)
+    completed = subprocess.run(['git', 'log', '-n1', sha], cwd=repoDir, capture_output=True)
+    if completed.stderr.decode('utf-8', errors='replace').find('fatal: bad object') != -1:
+      return False
+    elif completed.returncode != 0:
+      # Don't send the acces token through the error logging system
+      strippedOutput = completed.stderr.replace(self.token.encode('utf8'), b'<TOKEN>')
+      raise GitLocalException("Log of repo {}, sha {} failed with code {}, "\
+        "message: {}".format(repo, sha, completed.returncode, strippedOutput))
+    else:
+      return True
+
+  def getCommitsFromHead(self, repo, headSha, source, limit=False, offset=False):
+    """
+    This function lists multiple commits, but it has a few limitations based on missing data from
+    github: (1) it can't fill in the comment count, (2) it doesn't know the github user IDs and
+    user names associated wtih the commit.
+    """
+    repoDir = self._getRepoWorkingDir(repo, source)
+    # Since git log can't escape stuff, create unique sentinals
+    startTok = 'xstart5147587x'
+    sepTok = 'xsep4983782x'
+    params = ['git', 'log', '--pretty={}{}'.format(
+      startTok,
+      sepTok.join(['%H','%T','%P','%an','%ae','%ai','%cn','%ce','%ci','%B'])
+    )]
+    if limit:
+      params.append('-n{}'.format(int(limit)))
+    if offset:
+      params.append('--skip={}'.format(int(offset)))
+    params.append(headSha)
+    completed = subprocess.run(params, cwd=repoDir, capture_output=True)
+    if completed.returncode != 0:
+      # Don't send the acces token through the error logging system
+      strippedOutput = completed.stderr.replace(self.token.encode('utf8'), b'<TOKEN>')
+      raise GitLocalException("Log of repo {}, sha {} failed with code {}, message: {}".format(
+        repo, headSha, completed.returncode, strippedOutput))
+    outstr = completed.stdout.decode('utf8', errors='replace')
+    commitLines = outstr.split(startTok)
+    commits = []
+    for rawCommit in commitLines:
+      # Strip off trailing newline as well
+      split = rawCommit.rstrip().split(sepTok)
+      if len(split) < 2:
+        continue
+      commits.append({
+        '_sdc_repository': repo,
+        'sha': split[0],
+        'commit': {
+          'author': {
+            'name': split[3],
+            'email': split[4],
+            'date': split[5],
+          },
+          'committer': {
+            'name': split[6],
+            'email': split[7],
+            'date': split[8],
+          },
+          'tree': {
+            'sha': split[1],
+          },
+          'message': split[9]
+          # Omit comment_count, since comments are a github thing
+          # Omit 'verification' since we don't care about signatures right now
+        },
+        # Omit node_id, since we strip it out
+        # Author and committer may also exist here in github along with info about github user IDs.
+        # We can't include those becuase we don't know them.
+        'parents': [] if split[2] == '' else list({
+          'sha': p,
+        } for p in split[2].split(' ')),
+        # Leave stats empty -- it isn't included when listing multiple commits
+        # Leave files empty -- it isn't included when listing multiple commits
+      })
+    return commits
+
+  def getCommitDiff(self, repo, sha, source):
+    """
+    Gets detailed information about a commit at a particular sha. This funcion assumes that the
+    head has already been fetched and this commit is available.
+    """
+    repoDir = self._getRepoWorkingDir(repo, source)
+    completed = subprocess.run(['git', 'diff', sha + '~1', sha], cwd=repoDir, capture_output=True)
+    # Special case -- first commit, diff instead with an empty tree
+    if completed.returncode != 0 and b"~1': unknown revision or path not in the working tree" \
+        in completed.stderr:
+      # 4b825dc642cb6eb9a060e54bf8d69288fbee4904 is the sha of the empty tree
+      completed = subprocess.run(['git', 'diff', '4b825dc642cb6eb9a060e54bf8d69288fbee4904',
+        sha], cwd=repoDir, capture_output=True)
+    if completed.returncode != 0:
+      # Don't send the acces token through the error logging system
+      strippedOutput = '' if not completed.stderr else \
+        completed.stderr.replace(self.token.encode('utf8'), b'<TOKEN>')
+      raise GitLocalException("Diff of repo {}, sha {} failed with code {}, message: {}".format(
+        repo, sha, completed.returncode, strippedOutput))
+
+    # Replace any invalid characters
+    # Also, don't allow nulls since we are treating data as strings downstream. (FFFD is unicode
+    # replacement character.)
+    outstr = completed.stdout.decode('utf8', errors='replace').replace('\u0000', '\uFFFD')
+    lines = outstr.split('\n')
+
+    parsed = parseDiffLines(lines)
+    for diff in parsed:
+      diff['commit_sha'] = sha
+
+    return parsed
+
+  def getAllHeads(self, repo, source):
+    repoDir = self._getRepoWorkingDir(repo, source)
+    completed = subprocess.run(['git', 'show-ref'], cwd=repoDir, capture_output=True)
+    # Special case -- first commit, diff instead with an empty tree
+    if completed.returncode != 0:
+      strippedOutput = '' if not completed.stderr else \
+        completed.stderr.replace(self.token.encode('utf8'), b'<TOKEN>')
+      raise GitLocalException("show-ref of repo {}, failed with code {}, message: {}".format(
+        repo, completed.returncode, strippedOutput))
+
+    outstr = completed.stdout.decode('utf8', errors='replace')
+    headLines = outstr.split('\n')
+    headMap = {}
+    for line in headLines:
+      if len(line) == 0:
+        continue
+      lineSplit = line.split(' ', 1)
+      headSha = lineSplit[0]
+      headRef = lineSplit[1]
+      headMap[headRef] = headSha
+
+    return headMap

--- a/tap_gitlab/gitlocal.py
+++ b/tap_gitlab/gitlocal.py
@@ -1,3 +1,6 @@
+# TODO: consolidate this with github's copy:
+# https://minware.atlassian.net/browse/MW-258
+
 import subprocess
 import sys
 import os

--- a/tap_gitlab/schemas/commit_files.json
+++ b/tap_gitlab/schemas/commit_files.json
@@ -1,0 +1,124 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "_sdc_repository": {
+      "type": ["string"]
+    },
+    "id": {
+      "type": ["null", "string"],
+      "description": "Unique identifier of commit, <_sdc_repository>/<sha>"
+    },
+    "sha": {
+      "type": ["null", "string"],
+      "description": "The git commit hash"
+    },
+    "parents": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "object"],
+        "additionalProperties": false,
+        "properties": {
+          "sha": {
+            "type": ["null", "string"],
+            "description": "The git hash of the parent commit"
+          }
+        }
+      }
+    },
+    "commit": {
+      "type": ["null", "object"],
+      "properties": {
+        "tree": {
+          "type": ["null", "object"],
+          "properties": {
+            "sha": {
+              "type": ["null", "string"]
+            }
+          }
+        },
+        "author": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "date": {
+              "type": ["null", "string"],
+              "format": "date-time",
+              "description": "The date the author committed the change"
+            },
+            "name": {
+              "type": ["null", "string"],
+              "description": "The author's name"
+            },
+            "email": {
+              "type": ["null", "string"],
+              "description": "The author's email"
+            }
+          }
+        },
+        "message": {
+          "type": ["null", "string"],
+          "description": "The commit message"
+        },
+        "committer": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "date": {
+              "type": ["null", "string"],
+              "format": "date-time",
+              "description": "The date the committer committed the change"
+            },
+            "name": {
+              "type": ["null", "string"],
+              "description": "The committer's name"
+            },
+            "email": {
+              "type": ["null", "string"],
+              "description": "The committer's email"
+            }
+          }
+        }
+      }
+    },
+    "files": {
+      "type": ["array"],
+      "items": {
+        "type": ["null", "object"],
+        "properties": {
+          "filename": {
+            "type": ["string"],
+            "description": "The full name of the file including its directory path, unique per commit"
+          },
+          "previous_filename": {
+            "type": ["null", "string"],
+            "description": "If the file was renamed, this was its full name in the parent commit"
+          },
+          "patch": {
+            "type": ["null", "string"],
+            "description": "A patch representing the changes to the file in this commit."
+          },
+          "is_binary": {
+            "type": ["boolean"],
+            "description": "The file is binary, so no patch is included and change counts are zero. Binary is determined by the presence of null bytes or sequences that cause UTF-8 decoding errors. This flag will not be set when adding binary files becuase those are indiscernable from adding zero-length files in the github api."
+          },
+          "is_large_patch": {
+            "type": ["boolean"],
+            "description": "The file is text, but the current patch was too large to include (> 1 MB). Change counts may or may not be non-zero."
+          },
+          "changetype": {
+            "type": ["string"],
+            "description": "The type of change -- one of: add, delete, edit, none. None means no change to the file, which may be the case if there's a rename."
+          },
+          "additions": {
+            "type": ["integer"],
+            "description": "The number of lines added by this change (0 for binary or large patch)."
+          },
+          "deletions": {
+            "type": ["integer"],
+            "description": "The number of lines deleted by this change (0 for binary or large patch)."
+          }
+        }
+      }
+    }
+  }
+}

--- a/tap_gitlab/schemas/refs.json
+++ b/tap_gitlab/schemas/refs.json
@@ -1,0 +1,16 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "_sdc_repository": {
+      "type": ["string"]
+    },
+    "ref": {
+      "type": ["string"],
+      "description": "The name of the ref"
+    },
+    "sha": {
+      "type": ["null", "string"],
+      "description": "The ref's commit hash"
+    }
+  }
+}


### PR DESCRIPTION
Adds changes to import commits using the same state system as github. Also adds commit_files import using gitlocal that works in a similar way to github.

## How was this tested:
- Ran regular version (no commit_files) from clean state on repotest, verified that all the output rows were there as expected and imported successfully into postgres.
- Ran commit_files version from clean state on repotest, verified that all the output rows were there as expected and imported successfully into postgres.
- Ran both regular and commit_files from previously emitted state, verified that older rows were skipped, though the latest PR was re-import, as are project_labels, users, branches, project_members, projects, which is all expected.
- Removed one head commit from the state and verified that both regular and commit_files just add that one commit to the output.

Will want to test this on a larger repo in production to verify that it works with larger data sets.