### PR TITLE
Set earliest start date to 1980-01-01 to avoid 500 error

### DIFF
--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -271,7 +271,7 @@ def get_start(entity):
     if entity not in STATE or parse_datetime(STATE[entity]) < parse_datetime(CONFIG['start_date']):
         dates_to_compare = [
             parse_datetime(CONFIG['start_date']),
-            datetime.datetime(1973, 3, 4, 0, 0, 0, 0, tzutc())
+            datetime.datetime(1980, 1, 1, 0, 0, 0, 0, tzutc())
         ]
         STATE[entity] = max(dates_to_compare).isoformat()
     return STATE[entity]


### PR DESCRIPTION
The start date we are using when one doesn't exist appears to cause problems with gitlab.

Oddly enough, the repo that is failing doesn't have commits before 2023, so not sure what they are trying to do that would cause a 500 for this one particular repo.

Anyways, 1980-01-01 seems reasonably far in the past for us to use as a base.  Previously 1973 was used because 1970-01-01 would cause 500.