### PR TITLE
Fix iid property and archived field for gitlab ingest

### DIFF
--- a/tap_gitlab/schemas/jobs.json
+++ b/tap_gitlab/schemas/jobs.json
@@ -237,7 +237,10 @@
             "format": "float"
         },
         "archived": {
-            "type": "boolean"
+            "type": [
+                "null",
+                "boolean"
+            ]
         },
         "allow_failure": {
             "type": [

--- a/tap_gitlab/schemas/pipelines.json
+++ b/tap_gitlab/schemas/pipelines.json
@@ -8,7 +8,10 @@
             "type": "integer"
         },
         "iid": {
-            "type": "integer"
+            "type": [
+                "null",
+                "integer"
+            ]
         },
         "project_id": {
             "type": "integer"

--- a/tap_gitlab/schemas/pipelines_extended.json
+++ b/tap_gitlab/schemas/pipelines_extended.json
@@ -8,7 +8,10 @@
             "type": "integer"
         },
         "iid": {
-            "type": "integer"
+            "type": [
+                "null",
+                "integer"
+            ]
         },
         "project_id": {
             "type": "integer"


### PR DESCRIPTION

These properties caused problems with certain repositories.  Relaxing the types to match the API.