### PR TITLE
retry json failures which appear to be transient

### DIFF
--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -1252,26 +1252,6 @@ def sync_project(pid, gitLocal):
 def do_sync():
     LOGGER.info("Starting sync")
 
-    # Debug variables for direct API call
-    PROCESS_RESOURCE_TYPE = "jobs"  # We only want jobs
-    DEBUG_PROJECT_ID = 31339255     # The specific project ID
-    DEBUG_PIPELINE_ID = 1370045321  # The specific pipeline ID
-
-    # If we're in debug mode, just make the direct API call
-    if PROCESS_RESOURCE_TYPE == "jobs":
-        url = CONFIG['api_url'] + f'/projects/{DEBUG_PROJECT_ID}/pipelines/{DEBUG_PIPELINE_ID}/jobs?include_retried=true'
-        try:
-            LOGGER.info(f"Making direct call to: {url}")
-            resp = request(url)
-            LOGGER.info(f"Response status: {resp.status_code}")
-            LOGGER.info(f"Response headers: {resp.headers}")
-            LOGGER.info(f"Response text: {resp.text}")
-            return
-        except Exception as e:
-            LOGGER.error(f"Error making direct call: {str(e)}")
-            return
-
-    # Original do_sync code...
     gids = list(filter(None, CONFIG['groups'].split(' ')))
     pids = list(filter(None, CONFIG['projects'].split(' ')))
 

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -366,7 +366,6 @@ def gen_request(url):
             params['page'] = int(next_page)
             resp = request(url, params)
             resp_json = resp.json()
-                
             # handle endpoints that return a single JSON object
             if isinstance(resp_json, dict):
                 yield resp_json

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -1239,6 +1239,26 @@ def sync_project(pid, gitLocal):
 def do_sync():
     LOGGER.info("Starting sync")
 
+    # Debug variables for direct API call
+    PROCESS_RESOURCE_TYPE = "jobs"  # We only want jobs
+    DEBUG_PROJECT_ID = 31339255     # The specific project ID
+    DEBUG_PIPELINE_ID = 1370045321  # The specific pipeline ID
+
+    # If we're in debug mode, just make the direct API call
+    if PROCESS_RESOURCE_TYPE == "jobs":
+        url = CONFIG['api_url'] + f'/projects/{DEBUG_PROJECT_ID}/pipelines/{DEBUG_PIPELINE_ID}/jobs?include_retried=true'
+        try:
+            LOGGER.info(f"Making direct call to: {url}")
+            resp = request(url)
+            LOGGER.info(f"Response status: {resp.status_code}")
+            LOGGER.info(f"Response headers: {resp.headers}")
+            LOGGER.info(f"Response text: {resp.text}")
+            return
+        except Exception as e:
+            LOGGER.error(f"Error making direct call: {str(e)}")
+            return
+
+    # Original do_sync code...
     gids = list(filter(None, CONFIG['groups'].split(' ')))
     pids = list(filter(None, CONFIG['projects'].split(' ')))
 

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -308,7 +308,7 @@ def get_start(entity):
 @backoff.on_exception(backoff.expo,
                       (requests.exceptions.RequestException, requests.exceptions.JSONDecodeError),
                       max_tries=5,
-                      giveup=lambda e: (hasattr(e, 'response') and e.response is not None and e.response.status_code != 429 and 400 <= e.response.status_code < 500),  # hasattr check needed since JSONDecodeError has no response
+                      giveup=lambda e: (hasattr(e, 'response') and e.response is not None and e.response.status_code != 429 and 400 <= e.response.status_code < 500),  # pylint: disable=line-too-long
                       factor=2)
 def request(url, params=None):
     params = params or {}

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -10,6 +10,8 @@ import singer
 from singer import Transformer, utils, metadata, metrics
 from singer.catalog import Catalog, CatalogEntry
 from singer.schema import Schema
+from dataclasses import dataclass
+from typing import Any
 
 import pytz
 import backoff
@@ -38,6 +40,19 @@ CONFIG = {
 }
 STATE = {}
 CATALOG = None
+
+@dataclass
+class GitlabResponse:
+    response: requests.Response
+    json_data: Any
+
+    @property
+    def status_code(self) -> int:
+        return self.response.status_code
+
+    @property
+    def headers(self):
+        return self.response.headers
 
 def parse_datetime(datetime_str):
     dt = isoparse(datetime_str)
@@ -308,9 +323,9 @@ def get_start(entity):
 @backoff.on_exception(backoff.expo,
                       (requests.exceptions.RequestException, requests.exceptions.JSONDecodeError),
                       max_tries=5,
-                      giveup=lambda e: (hasattr(e, 'response') and e.response is not None and e.response.status_code != 429 and 400 <= e.response.status_code < 500),  # pylint: disable=line-too-long
+                      giveup=lambda e: (hasattr(e, 'response') and e.response is not None and e.response.status_code != 429 and 400 <= e.response.status_code < 500),  # hasattr check needed since JSONDecodeError has no response
                       factor=2)
-def request(url, params=None):
+def request(url, params=None) -> GitlabResponse:
     params = params or {}
 
     headers = { "Private-Token": CONFIG['private_token'] }
@@ -330,16 +345,16 @@ def request(url, params=None):
         LOGGER.info("Reason: {} - {}".format(resp.status_code, resp.content))
         raise ResourceInaccessible
 
-    # Try to parse JSON response - will retry if it fails
+    # Parse JSON response - will retry if it fails
     try:
-        resp.json()
+        resp_json = resp.json()
     except requests.exceptions.JSONDecodeError as e:
         LOGGER.warning(f"JSON decode error: {str(e)}")
         LOGGER.warning(f"Response status code: {resp.status_code}")
         LOGGER.warning(f"Response text: {resp.text}")
         raise  # Let backoff retry
 
-    return resp
+    return GitlabResponse(response=resp, json_data=resp_json)
 
 def gen_request(url):
     if 'labels' in url:
@@ -363,16 +378,15 @@ def gen_request(url):
     try:
         while next_page:
             params['page'] = int(next_page)
-            resp = request(url, params)
-            resp_json = resp.json()
+            gitlab_resp = request(url, params)
             # handle endpoints that return a single JSON object
-            if isinstance(resp_json, dict):
-                yield resp_json
+            if isinstance(gitlab_resp.json_data, dict):
+                yield gitlab_resp.json_data
             # handle endpoints that return an array of JSON objects
             else:
-                for row in resp_json:
+                for row in gitlab_resp.json_data:
                     yield row
-            next_page = resp.headers.get('X-Next-Page', None)
+            next_page = gitlab_resp.headers.get('X-Next-Page', None)
     except ResourceInaccessible as exc:
         # Don't halt execution if a Resource is Inaccessible
         # Just skip it and continue with the rest of the extraction
@@ -998,7 +1012,7 @@ def sync_group(gid, pids, gitLocal):
     url = get_url(entity="groups", id=gid)
 
     try:
-        data = request(url).json()
+        data = request(url).json_data
     except ResourceInaccessible as exc:
         # Don't halt execution if a Group is Inaccessible
         # Just skip it and continue with the rest of the extraction
@@ -1179,7 +1193,7 @@ def sync_project(pid, gitLocal):
     url = get_url(entity="projects", id=pid)
 
     try:
-        data = request(url).json()
+        data = request(url).json_data
     except ResourceInaccessible as exc:
         # Don't halt execution if a Project is Inaccessible
         # Just skip it and continue with the rest of the extraction

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -365,18 +365,7 @@ def gen_request(url):
         while next_page:
             params['page'] = int(next_page)
             resp = request(url, params)
-            try:
-                resp_json = resp.json()
-            except (requests.exceptions.JSONDecodeError, simplejson.errors.JSONDecodeError) as e:
-                # Log the error and response details
-                LOGGER.warning(f"JSON decode error on first attempt: {str(e)}")
-                LOGGER.warning(f"Response status code: {resp.status_code}")
-                LOGGER.warning(f"Response text: {resp.text}")
-                
-                # Retry the request once
-                LOGGER.info("Retrying request once...")
-                resp = request(url, params)
-                resp_json = resp.json()  # If this fails again, let it raise
+            resp_json = resp.json()
                 
             # handle endpoints that return a single JSON object
             if isinstance(resp_json, dict):
@@ -1232,7 +1221,6 @@ def sync_project(pid, gitLocal):
         commitFiles = True
 
     if commitFiles:
-        return
         heads = sync_branches(data, True)
         # This function will utilize the state so that PR heads won't be returned if they haven't
         # been updated since the last run.

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -20,7 +20,6 @@ import psutil
 import gc
 import asyncio
 from urllib.parse import urlparse
-import simplejson
 
 from gitlocal import GitLocal
 
@@ -307,7 +306,7 @@ def get_start(entity):
                       value=lambda r: int(r.headers.get("Retry-After")), 
                       jitter=None)
 @backoff.on_exception(backoff.expo,
-                      (requests.exceptions.RequestException, requests.exceptions.JSONDecodeError, simplejson.errors.JSONDecodeError),
+                      (requests.exceptions.RequestException, requests.exceptions.JSONDecodeError),
                       max_tries=5,
                       giveup=lambda e: (hasattr(e, 'response') and e.response is not None and e.response.status_code != 429 and 400 <= e.response.status_code < 500),  # hasattr check needed since JSONDecodeError has no response
                       factor=2)
@@ -334,7 +333,7 @@ def request(url, params=None):
     # Try to parse JSON response - will retry if it fails
     try:
         resp.json()
-    except (requests.exceptions.JSONDecodeError, simplejson.errors.JSONDecodeError) as e:
+    except requests.exceptions.JSONDecodeError as e:
         LOGGER.warning(f"JSON decode error: {str(e)}")
         LOGGER.warning(f"Response status code: {resp.status_code}")
         LOGGER.warning(f"Response text: {resp.text}")


### PR DESCRIPTION
This change makes use of the existing retry and backoff logic for json decode failures that we see in MW-5281. These interestingly appear transient. I'm making a guess that retrying the failed json parsing will eventually succeed.

I validated that this doesn't break normal requests, but it is hard to validate that it will work for the problem we're trying to solve.