### PR TITLE
fix: allow null values in pipelines_extended user object

### DIFF
--- a/tap_gitlab/schemas/pipelines_extended.json
+++ b/tap_gitlab/schemas/pipelines_extended.json
@@ -74,19 +74,31 @@
                     ]
                 },
                 "username": {
-                    "type": "string"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 },
                 "id": {
                     "type": "integer"
                 },
                 "state": {
-                    "type": "string"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 },
                 "avatar_url": {
-                    "type": "string"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 },
                 "web_url": {
-                    "type": "string"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 }
             }
         },


### PR DESCRIPTION
## Summary
- GitLab API returns `null` for `user.avatar_url` when users don't have avatars configured
- The `pipelines_extended` schema was requiring non-null strings, causing `SchemaMismatch` errors
- Updated `username`, `state`, `avatar_url`, and `web_url` fields in the user object to allow null values, matching the pattern used in `jobs.json`

## Test plan
- [ ] Run this in prod for the failing org. See minwareco/scheduled/pull/1650

Fixes MW-10308

🤖 Generated with [Claude Code](https://claude.ai/code)