### PR TITLE
fix: handle non-JSON responses from misconfigured GitLab instances

### DIFF
--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -362,14 +362,18 @@ def request(url, params=None) -> GitlabResponse:
         LOGGER.info("Reason: {} - {}".format(resp.status_code, resp.content))
         raise ResourceInaccessible
 
-    # Parse JSON response - will retry if it fails
+    # Parse JSON response
     try:
         resp_json = resp.json()
     except requests.exceptions.JSONDecodeError as e:
-        LOGGER.warning(f"JSON decode error: {str(e)}")
+        LOGGER.warning(f"JSON decode error for {url}: {str(e)}")
         LOGGER.warning(f"Response status code: {resp.status_code}")
-        LOGGER.warning(f"Response text: {resp.text}")
-        raise  # Let backoff retry
+        LOGGER.warning(f"Response text (first 500 chars): {resp.text[:500]}")
+        # If the server returns 200 with non-JSON (e.g. HTML redirect page),
+        # retrying won't help — treat as inaccessible resource
+        if resp.status_code == 200:
+            raise ResourceInaccessible
+        raise  # Other status codes: let backoff retry
 
     return GitlabResponse(response=resp, json_data=resp_json)
 


### PR DESCRIPTION
## Summary
- When a self-hosted GitLab instance returns HTTP 200 with an HTML body (e.g. a redirect/landing page) instead of JSON, the tap now raises `ResourceInaccessible` instead of retrying and eventually crashing
- This allows `sync_group` to skip the affected group and continue extraction for the rest of the org
- Truncates logged response text to 500 chars to avoid flooding logs with full HTML pages

## Context
A customer's self-hosted GitLab at `rickybobbyllc.com` returns an HTML redirect page (`window.location.href="/lander"`) with HTTP 200 for group API requests. The previous code would retry 5 times via backoff (since 200 isn't in the 400-499 giveup range), then crash the entire sync job with a `JSONDecodeError`.

## Test plan
[ ] Dev ingest for an org

Fixes [MW-10502](https://minware.atlassian.net/browse/MW-10502)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MW-10502]: https://minware.atlassian.net/browse/MW-10502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ