### PR TITLE
Handle GitLocalRepoNotFoundException to skip unavailable repos

### DIFF
--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -24,7 +24,7 @@ import gc
 import asyncio
 from urllib.parse import urlparse
 
-from minware_singer_utils import GitLocal, SecureLogger
+from minware_singer_utils import GitLocal, GitLocalRepoNotFoundException, SecureLogger
 
 PER_PAGE_MAX = 100
 CONFIG = {
@@ -1405,12 +1405,20 @@ def do_sync():
     LOGGER.info(gids)
 
     for gid in gids:
-        sync_group(gid, pids, gitLocal, commits_only, selected_stream_ids)
+        try:
+            sync_group(gid, pids, gitLocal, commits_only, selected_stream_ids)
+        except GitLocalRepoNotFoundException as e:
+            LOGGER.warning(f'Repository for group {gid} not found, skipping: {e}')
+            continue
 
     if not gids:
         # When not syncing groups
         for pid in pids:
-            sync_project(pid, gitLocal, commits_only, selected_stream_ids)
+            try:
+                sync_project(pid, gitLocal, commits_only, selected_stream_ids)
+            except GitLocalRepoNotFoundException as e:
+                LOGGER.warning(f'Repository for project {pid} not found, skipping: {e}')
+                continue
 
     # Write the final STATE
     # This fixes syncing using groups, which don't emit a STATE message

--- a/tap_gitlab/__init__.py
+++ b/tap_gitlab/__init__.py
@@ -1112,7 +1112,11 @@ def sync_group(gid, pids, gitLocal, commits_only, selected_stream_ids=None):
         group_projects_url = get_url(entity="group_projects", id=gid)
         for project in gen_request(group_projects_url):
             if project["id"]:
-                sync_project(project["id"], gitLocal, commits_only, selected_stream_ids)
+                try:
+                    sync_project(project["id"], gitLocal, commits_only, selected_stream_ids)
+                except GitLocalRepoNotFoundException as e:
+                    LOGGER.warning(f'Repository for project {project["id"]} not found, skipping: {e}')
+                    continue
 
         group_subgroups_url = get_url("group_subgroups", id=gid)
         for group in gen_request(group_subgroups_url):
@@ -1122,7 +1126,11 @@ def sync_group(gid, pids, gitLocal, commits_only, selected_stream_ids=None):
         # Sync only specific projects of the group, if explicit projects are provided
         for pid in pids:
             if pid.startswith(data['full_path'] + '/') or pid in [str(p['id']) for p in data['projects']]:
-                sync_project(pid, gitLocal, commits_only, selected_stream_ids)
+                try:
+                    sync_project(pid, gitLocal, commits_only, selected_stream_ids)
+                except GitLocalRepoNotFoundException as e:
+                    LOGGER.warning(f'Repository for project {pid} not found, skipping: {e}')
+                    continue
 
     sync_milestones(data, "group")
 
@@ -1405,11 +1413,7 @@ def do_sync():
     LOGGER.info(gids)
 
     for gid in gids:
-        try:
-            sync_group(gid, pids, gitLocal, commits_only, selected_stream_ids)
-        except GitLocalRepoNotFoundException as e:
-            LOGGER.warning(f'Repository for group {gid} not found, skipping: {e}')
-            continue
+        sync_group(gid, pids, gitLocal, commits_only, selected_stream_ids)
 
     if not gids:
         # When not syncing groups


### PR DESCRIPTION
## Summary
- Catches `GitLocalRepoNotFoundException` in both `sync_group()` and `sync_project()` calls to skip unavailable repos instead of failing the entire ingest job
- Logs a warning and continues to the next repository

## Test plan
- [ ] Verify unavailable repos are skipped gracefully during ingest
- [ ] Verify other `GitLocalException` errors still propagate

Depends on: minwareco/minware-singer-utils#22
Jira: [MW-10497](https://minware.atlassian.net/browse/MW-10497)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MW-10497]: https://minware.atlassian.net/browse/MW-10497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ